### PR TITLE
Exclude schema and rake

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -5,7 +5,7 @@ AllCops:
     - 'bin/**/*'
     - 'lib/tasks/**/*'
     - 'config/**/*'
-
+    - 'db/schema.rb'
 Metrics/LineLength:
   Max: 120
 
@@ -19,6 +19,7 @@ Metrics/MethodLength:
 
 Metrics/BlockLength:
   Exclude:
+    - 'lib/tasks/*.rake'
     - 'spec/**/*_spec.rb'
     - 'config/routes.rb'
 


### PR DESCRIPTION
 - schema is autogenerated and needs to be excluded 
 - rake tasks are defined from blocks so limit there shouldn't apply